### PR TITLE
Py3k compatibility

### DIFF
--- a/src/django_markup/fields.py
+++ b/src/django_markup/fields.py
@@ -1,3 +1,5 @@
+import six
+
 from django.db.models.fields import CharField, TextField
 from django.utils.translation import ugettext_lazy
 from django.core.exceptions import ImproperlyConfigured
@@ -13,7 +15,7 @@ class MarkupField(CharField):
         if default:
             if default not in formatter.filter_list:
                 raise ImproperlyConfigured("'%s' is not a registered markup filter. Registered filters are: %s." %
-                                           (default, ', '.join(formatter.filter_list.iterkeys())))
+                                           (default, ', '.join(six.iterkeys(formatter.filter_list))))
             kwargs.setdefault('default', default)
 
         kwargs.setdefault('max_length', 255)

--- a/src/django_markup/markup.py
+++ b/src/django_markup/markup.py
@@ -78,7 +78,7 @@ class MarkupFormatter(object):
         # Check that the filter_name is a registered markup filter
         if filter_name not in self.filter_list:
             raise ValueError("'%s' is not a registered markup filter. Registered filters are: %s." %
-                             (filter_name, ', '.join(self.filter_list.iterkeys())))
+                             (filter_name, ', '.join(six.iterkeys(self.filter_list))))
         filter_class = self.filter_list[filter_name]
 
         # Read global filter settings and apply it


### PR DESCRIPTION
This PR is slightly better than #11 because this change also handles the `iterkeys()`, and maintains backwards compatibility with Python 2.x by using `six`.